### PR TITLE
change socket init

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,10 @@
 # Changelog
 
+[Unreleased]
+
+### Changed
+- socket on client-side have to be init manually to get return value
+
 
 ## [0.3.0] - 2019-09-09
 

--- a/include/libKitsuneNetwork/abstract_socket.h
+++ b/include/libKitsuneNetwork/abstract_socket.h
@@ -40,7 +40,7 @@ public:
     AbstractSocket();
     ~AbstractSocket();
 
-    static Kitsune::Network::CleanupThread* m_cleanup;
+    virtual bool initSocket() = 0;
 
     // trigger-control
     bool addNetworkTrigger(NetworkTrigger* trigger);
@@ -53,6 +53,8 @@ public:
 
     bool closeSocket();
 
+    static Kitsune::Network::CleanupThread* m_cleanup;
+
 protected:
     bool m_clientSide = false;
     int m_socket = 0;
@@ -63,7 +65,6 @@ protected:
     void run();
     bool waitForMessage();
 
-    virtual bool initSocket() = 0;
     virtual long recvData(int socket,
                           void* bufferPosition,
                           const size_t bufferSize,

--- a/include/libKitsuneNetwork/tcp/tcp_socket.h
+++ b/include/libKitsuneNetwork/tcp/tcp_socket.h
@@ -26,13 +26,13 @@ public:
     TcpSocket(const std::string address,
               const uint16_t port);
     TcpSocket(const int socketFd);
+    bool initSocket();
 
 protected:
     std::string m_address = "";
     uint16_t m_port = 0;
     sockaddr_in m_socketAddr;
 
-    bool initSocket();
     long recvData(int socket,
                   void* bufferPosition,
                   const size_t bufferSize,

--- a/include/libKitsuneNetwork/tls_tcp/tls_tcp_socket.h
+++ b/include/libKitsuneNetwork/tls_tcp/tls_tcp_socket.h
@@ -35,6 +35,8 @@ public:
                  const std::string keyFile);
     ~TlsTcpSocket();
 
+    bool initOpenssl();
+
 protected:
     SSL_CTX* m_ctx;
     SSL* m_ssl;
@@ -50,7 +52,6 @@ protected:
                      const size_t bufferSize,
                      int);
 
-    bool initOpenssl();
     void cleanupOpenssl();
 };
 

--- a/include/libKitsuneNetwork/unix/unix_socket.h
+++ b/include/libKitsuneNetwork/unix/unix_socket.h
@@ -22,11 +22,11 @@ public:
     UnixSocket(const std::string socketFile);
     UnixSocket(const int socketFd);
 
+    bool initSocket();
+
 protected:
     std::string m_socketFile = "";
     sockaddr_un m_socketAddr;
-
-    bool initSocket();
 
     long recvData(int socket,
                   void* bufferPosition,

--- a/src/tcp/tcp_socket.cpp
+++ b/src/tcp/tcp_socket.cpp
@@ -29,8 +29,6 @@ TcpSocket::TcpSocket(const std::string address,
     m_address = address;
     m_port = port;
     m_clientSide = true;
-
-    initSocket();
 }
 
 /**

--- a/src/tls_tcp/tls_tcp_server.cpp
+++ b/src/tls_tcp/tls_tcp_server.cpp
@@ -58,6 +58,7 @@ TlsTcpServer::waitForIncomingConnection()
     TlsTcpSocket* tcpSocket = new TlsTcpSocket(fd,
                                                m_certFile,
                                                m_keyFile);
+    tcpSocket->initOpenssl();
     for(uint32_t i = 0; i < m_trigger.size(); i++) 
     {
         tcpSocket->addNetworkTrigger(m_trigger.at(i));

--- a/src/tls_tcp/tls_tcp_socket.cpp
+++ b/src/tls_tcp/tls_tcp_socket.cpp
@@ -32,16 +32,6 @@ TlsTcpSocket::TlsTcpSocket(const std::string address,
 {
     m_certFile = certFile;
     m_keyFile = keyFile;
-
-    // init ssl
-    initOpenssl();
-
-    // try to connect to server
-    const int result = SSL_connect(m_ssl);
-    if(result <= 0) {
-        ERR_print_errors_fp(stderr);
-    }
-
 }
 
 /**
@@ -59,15 +49,6 @@ TlsTcpSocket::TlsTcpSocket(const int socketFd,
 {
     m_certFile = certFile;
     m_keyFile = keyFile;
-
-    // init ssl
-    initOpenssl();
-
-    // try to accept incoming ssl-connection
-    int result = SSL_accept(m_ssl);
-    if(result <= 0) {
-        ERR_print_errors_fp(stderr);
-    }
 }
 
 /**
@@ -127,6 +108,26 @@ TlsTcpSocket::initOpenssl()
         return false;
     }
     SSL_set_fd(m_ssl, m_socket);
+
+    // process tls-handshake
+    if(m_clientSide)
+    {
+        // try to connect to server
+        result = SSL_connect(m_ssl);
+        if(result <= 0)
+        {
+            ERR_print_errors_fp(stderr);
+            return false;
+        }
+    }
+    else
+    {
+        // try to accept incoming ssl-connection
+        int result = SSL_accept(m_ssl);
+        if(result <= 0) {
+            ERR_print_errors_fp(stderr);
+        }
+    }
 
     return true;
 }

--- a/src/unix/unix_socket.cpp
+++ b/src/unix/unix_socket.cpp
@@ -27,7 +27,6 @@ UnixSocket::UnixSocket(const std::string socketFile)
 {
     m_socketFile = socketFile;
     m_clientSide = true;
-    initSocket();
 }
 
 /**

--- a/tests/libKitsuneNetwork/tcp/tcp_socket_tcp_server_test.cpp
+++ b/tests/libKitsuneNetwork/tcp/tcp_socket_tcp_server_test.cpp
@@ -44,9 +44,14 @@ TcpSocket_TcpServer_Test::initTestCase()
 void
 TcpSocket_TcpServer_Test::checkConnectionInit()
 {
+    // init server
     UNITTEST(m_server->initServer(12345), true);
     UNITTEST(m_server->start(), true);
-    m_socketSocketSide = new TcpSocket("127.0.0.1", 12345);
+
+    // init client
+    m_socketClientSide = new TcpSocket("127.0.0.1", 12345);
+    UNITTEST(m_socketClientSide->initSocket(), true);
+
     usleep(10000);
 
     UNITTEST(m_server->getNumberOfSockets(), 1);
@@ -66,7 +71,7 @@ TcpSocket_TcpServer_Test::checkLittleDataTransfer()
     usleep(10000);
 
     std::string sendMessage("poipoipoi");
-    UNITTEST(m_socketSocketSide->sendMessage(sendMessage), true);
+    UNITTEST(m_socketClientSide->sendMessage(sendMessage), true);
     usleep(10000);
     UNITTEST(m_buffer->getNumberOfWrittenBytes(), 9);
 
@@ -90,10 +95,10 @@ void
 TcpSocket_TcpServer_Test::checkBigDataTransfer()
 {
     std::string sendMessage = "poi";
-    UNITTEST(m_socketSocketSide->sendMessage(sendMessage), true);
+    UNITTEST(m_socketClientSide->sendMessage(sendMessage), true);
     for(uint32_t i = 0; i < 99999; i++)
     {
-        m_socketSocketSide->sendMessage(sendMessage);
+        m_socketClientSide->sendMessage(sendMessage);
     }
     usleep(10000);
     uint64_t totalIncom = m_buffer->getNumberOfWrittenBytes();

--- a/tests/libKitsuneNetwork/tcp/tcp_socket_tcp_server_test.h
+++ b/tests/libKitsuneNetwork/tcp/tcp_socket_tcp_server_test.h
@@ -33,7 +33,7 @@ private:
     void cleanupTestCase();
 
     TcpServer* m_server = nullptr;
-    TcpSocket* m_socketSocketSide = nullptr;
+    TcpSocket* m_socketClientSide = nullptr;
     TcpSocket* m_socketServerSide = nullptr;
     DummyBuffer* m_buffer = nullptr;
 };

--- a/tests/libKitsuneNetwork/tls_tcp/tls_tcp_socket_tls_tcp_server_test.cpp
+++ b/tests/libKitsuneNetwork/tls_tcp/tls_tcp_socket_tls_tcp_server_test.cpp
@@ -49,12 +49,18 @@ TlsTcpSocket_TcpServer_Test::initTestCase()
 void
 TlsTcpSocket_TcpServer_Test::checkConnectionInit()
 {
+    // init server
     UNITTEST(m_server->initServer(12345), true);
     UNITTEST(m_server->start(), true);
-    m_socketSocketSide = new TlsTcpSocket("127.0.0.1",
+
+    // init client
+    m_socketClientSide = new TlsTcpSocket("127.0.0.1",
                                           12345,
                                           "/tmp/cert.pem",
                                           "/tmp/key.pem");
+    UNITTEST(m_socketClientSide->initSocket(), true);
+    UNITTEST(m_socketClientSide->initOpenssl(), true);
+
     usleep(10000);
 
     UNITTEST(m_server->getNumberOfSockets(), 1);
@@ -74,7 +80,7 @@ TlsTcpSocket_TcpServer_Test::checkLittleDataTransfer()
     usleep(10000);
 
     std::string sendMessage("poipoipoi");
-    UNITTEST(m_socketSocketSide->sendMessage(sendMessage), true);
+    UNITTEST(m_socketClientSide->sendMessage(sendMessage), true);
     usleep(10000);
     UNITTEST(m_buffer->getNumberOfWrittenBytes(), 9);
 
@@ -98,10 +104,10 @@ void
 TlsTcpSocket_TcpServer_Test::checkBigDataTransfer()
 {
     std::string sendMessage = "poi";
-    UNITTEST(m_socketSocketSide->sendMessage(sendMessage), true);
+    UNITTEST(m_socketClientSide->sendMessage(sendMessage), true);
     for(uint32_t i = 0; i < 99999; i++)
     {
-        m_socketSocketSide->sendMessage(sendMessage);
+        m_socketClientSide->sendMessage(sendMessage);
     }
     usleep(100000);
     uint64_t totalIncom = m_buffer->getNumberOfWrittenBytes();

--- a/tests/libKitsuneNetwork/tls_tcp/tls_tcp_socket_tls_tcp_server_test.h
+++ b/tests/libKitsuneNetwork/tls_tcp/tls_tcp_socket_tls_tcp_server_test.h
@@ -33,7 +33,7 @@ private:
     void cleanupTestCase();
 
     TlsTcpServer* m_server = nullptr;
-    TlsTcpSocket* m_socketSocketSide = nullptr;
+    TlsTcpSocket* m_socketClientSide = nullptr;
     TlsTcpSocket* m_socketServerSide = nullptr;
     DummyBuffer* m_buffer = nullptr;
 };

--- a/tests/libKitsuneNetwork/unix/unix_socket_unix_server_test.cpp
+++ b/tests/libKitsuneNetwork/unix/unix_socket_unix_server_test.cpp
@@ -44,9 +44,14 @@ UnixSocket_UnixServer_Test::initTestCase()
 void
 UnixSocket_UnixServer_Test::checkConnectionInit()
 {
+    // init server
     UNITTEST(m_server->initServer("/tmp/sock.uds"), true);
     UNITTEST(m_server->start(), true);
-    m_socketSocketSide = new UnixSocket("/tmp/sock.uds");
+
+    // init client
+    m_socketClientSide = new UnixSocket("/tmp/sock.uds");
+    UNITTEST(m_socketClientSide->initSocket(), true);
+
     usleep(10000);
 
     UNITTEST(m_server->getNumberOfSockets(), 1);
@@ -66,7 +71,7 @@ UnixSocket_UnixServer_Test::checkLittleDataTransfer()
     usleep(10000);
 
     std::string sendMessage("poipoipoi");
-    UNITTEST(m_socketSocketSide->sendMessage(sendMessage), true);
+    UNITTEST(m_socketClientSide->sendMessage(sendMessage), true);
     usleep(10000);
     UNITTEST(m_buffer->getNumberOfWrittenBytes(), 9);
 
@@ -90,10 +95,10 @@ void
 UnixSocket_UnixServer_Test::checkBigDataTransfer()
 {
     std::string sendMessage = "poi";
-    UNITTEST(m_socketSocketSide->sendMessage(sendMessage), true);
+    UNITTEST(m_socketClientSide->sendMessage(sendMessage), true);
     for(uint32_t i = 0; i < 99999; i++)
     {
-        m_socketSocketSide->sendMessage(sendMessage);
+        m_socketClientSide->sendMessage(sendMessage);
     }
     usleep(10000);
     uint64_t totalIncom = m_buffer->getNumberOfWrittenBytes();

--- a/tests/libKitsuneNetwork/unix/unix_socket_unix_server_test.h
+++ b/tests/libKitsuneNetwork/unix/unix_socket_unix_server_test.h
@@ -33,7 +33,7 @@ private:
     void cleanupTestCase();
 
     UnixServer* m_server = nullptr;
-    UnixSocket* m_socketSocketSide = nullptr;
+    UnixSocket* m_socketClientSide = nullptr;
     UnixSocket* m_socketServerSide = nullptr;
     DummyBuffer* m_buffer = nullptr;
 };


### PR DESCRIPTION
Init sockets on client-side now have to be done manually to get the return-value
to check, if init was successful.