### PR TITLE
fixed false error-message

### DIFF
--- a/src/tcp/tcp_server.cpp
+++ b/src/tcp/tcp_server.cpp
@@ -98,6 +98,11 @@ AbstractSocket* TcpServer::waitForIncomingConnection()
 
     //make new connection
     int fd = accept(m_serverSocket, reinterpret_cast<struct sockaddr*>(&m_server), &length);
+
+    if(m_abort) {
+        return nullptr;
+    }
+
     if(fd < 0)
     {
         LOG_error("Failed accept incoming connection on tcp-server with "

--- a/src/tls_tcp/tls_tcp_server.cpp
+++ b/src/tls_tcp/tls_tcp_server.cpp
@@ -52,6 +52,11 @@ TlsTcpServer::waitForIncomingConnection()
 
     //make new connection
     int fd = accept(m_serverSocket, reinterpret_cast<struct sockaddr*>(&m_server), &length);
+
+    if(m_abort) {
+        return nullptr;
+    }
+
     if(fd < 0)
     {
         LOG_error("Failed accept incoming connection on encrypted tcp-server with "

--- a/src/unix/unix_server.cpp
+++ b/src/unix/unix_server.cpp
@@ -89,6 +89,11 @@ UnixServer::waitForIncomingConnection()
 
     //make new connection
     int fd = accept(m_serverSocket, reinterpret_cast<struct sockaddr*>(&m_server), &length);
+
+    if(m_abort) {
+        return nullptr;
+    }
+
     if(fd < 0)
     {
         LOG_error("Failed accept incoming connection on unix-server with address: " + m_socketFile);


### PR DESCRIPTION
While closing a server, the log had registered an error-message, which is no
error. This was fixed with an additional check in all three servers.

close #19