### PR TITLE
changed trigger-handling in sockets

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,6 +11,8 @@
 - socket-constructors for server-side are now private 
 - renamed NetworkTrigger to MessageTrigger
 - renamed UnixSocket to UnixDomainSocket and UnixServer to UnixDomainServer
+- reduced the list of triggers in the sockets to only one trigger-object per socket
+
 
 ## [0.3.0] - 2019-09-09
 

--- a/include/libKitsuneNetwork/abstract_socket.h
+++ b/include/libKitsuneNetwork/abstract_socket.h
@@ -51,9 +51,7 @@ public:
     socketTypes getType();
 
     // trigger-control
-    bool addNetworkTrigger(MessageTrigger* trigger);
-    bool removeNetworkTrigger(const uint32_t index);
-    void clearNetworkTrigger();
+    void setMessageTrigger(MessageTrigger* trigger);
 
     bool sendMessage(const std::string &message);
     bool sendMessage(const void *message,
@@ -69,7 +67,7 @@ protected:
     socketTypes m_type = UNDEFINED_TYPE;
 
     MessageRingBuffer m_recvBuffer;
-    std::vector<MessageTrigger*> m_trigger;
+    MessageTrigger* m_trigger;
 
     void run();
     bool waitForMessage();

--- a/src/abstract_socket.cpp
+++ b/src/abstract_socket.cpp
@@ -36,7 +36,6 @@ AbstractSocket::AbstractSocket()
 AbstractSocket::~AbstractSocket()
 {
     closeSocket();
-    clearNetworkTrigger();
 }
 
 /**
@@ -56,44 +55,10 @@ AbstractSocket::getType()
  *
  * @return false, if object was nullptr, else true
  */
-bool
-AbstractSocket::addNetworkTrigger(MessageTrigger *trigger)
-{
-    if(trigger == nullptr) {
-        return false;
-    }
-
-    m_trigger.push_back(trigger);
-
-    return true;
-}
-
-/**
- * remove a specific trigger from the socket
- *
- * @param index index of the trigger in the list
- *
- * @return false, if index too high, else tru
- */
-bool
-AbstractSocket::removeNetworkTrigger(const uint32_t index)
-{
-    if(m_trigger.size() <= index) {
-        return false;
-    }
-
-    m_trigger.erase(m_trigger.begin() + index);
-
-    return true;
-}
-
-/**
- * delete all trigger-objects from the socket
- */
 void
-AbstractSocket::clearNetworkTrigger()
+AbstractSocket::setMessageTrigger(MessageTrigger *trigger)
 {
-    m_trigger.clear();
+    m_trigger = trigger;
 }
 
 /**
@@ -185,9 +150,9 @@ AbstractSocket::waitForMessage()
     m_recvBuffer.readWriteDiff = (m_recvBuffer.readWriteDiff + static_cast<uint64_t>(recvSize));
 
     // add all trigger to the new socket
-    for(uint64_t i = 0; i < m_trigger.size(); i++)
+    if(m_trigger != nullptr)
     {
-        const uint64_t readBytes = m_trigger[i]->runTask(m_recvBuffer, this);
+        const uint64_t readBytes = m_trigger->runTask(m_recvBuffer, this);
 
         m_recvBuffer.readPosition = (m_recvBuffer.readPosition + readBytes)
                                     % m_recvBuffer.totalBufferSize;

--- a/src/tcp/tcp_server.cpp
+++ b/src/tcp/tcp_server.cpp
@@ -118,7 +118,7 @@ AbstractSocket* TcpServer::waitForIncomingConnection()
 
     // create new socket-object from file-descriptor
     TcpSocket* tcpSocket = new TcpSocket(fd);
-    tcpSocket->addNetworkTrigger(m_messageTrigger);
+    tcpSocket->setMessageTrigger(m_messageTrigger);
     m_connectionTrigger->handleConnection(tcpSocket);
 
     // append new socket to the list

--- a/src/tls_tcp/tls_tcp_server.cpp
+++ b/src/tls_tcp/tls_tcp_server.cpp
@@ -79,7 +79,7 @@ TlsTcpServer::waitForIncomingConnection()
     LOG_info("Successfully accepted incoming connection on encrypted tcp-socket server with "
              "port : " + std::to_string(m_port));
 
-    tcpSocket->addNetworkTrigger(m_messageTrigger);
+    tcpSocket->setMessageTrigger(m_messageTrigger);
     m_connectionTrigger->handleConnection(tcpSocket);
 
     // append new socket to the list

--- a/src/unix/unix_domain_server.cpp
+++ b/src/unix/unix_domain_server.cpp
@@ -108,7 +108,7 @@ UnixDomainServer::waitForIncomingConnection()
 
     // create new socket-object from file-descriptor
     UnixDomainSocket* unixSocket = new UnixDomainSocket(fd);
-    unixSocket->addNetworkTrigger(m_messageTrigger);
+    unixSocket->setMessageTrigger(m_messageTrigger);
     m_connectionTrigger->handleConnection(unixSocket);
 
     // append new socket to the list


### PR DESCRIPTION
The Sockets had a list of message-trigger, but this was reduced to only
one trigger-object per socket, to reduce complexity and it seems, that
one is enough.