### PR TITLE
add precheck for sockets

### DIFF
--- a/include/libKitsuneNetwork/abstract_socket.h
+++ b/include/libKitsuneNetwork/abstract_socket.h
@@ -62,6 +62,7 @@ public:
     static Kitsune::Network::CleanupThread* m_cleanup;
 
 protected:
+    bool m_isConnected = false;
     bool m_clientSide = false;
     int m_socket = 0;
     socketTypes m_type = UNDEFINED_TYPE;

--- a/src/tcp/tcp_socket.cpp
+++ b/src/tcp/tcp_socket.cpp
@@ -39,11 +39,16 @@ TcpSocket::TcpSocket(const std::string address,
 bool
 TcpSocket::initClientSide()
 {
+    if(m_isConnected) {
+        return true;
+    }
+
     bool result = initSocket();
     if(result == false) {
         return false;
     }
 
+    m_isConnected = true;
     LOG_INFO("Successfully initialized tcp-socket client to targe: " + m_address);
 
     return true;
@@ -61,6 +66,7 @@ TcpSocket::TcpSocket(const int socketFd)
     m_socket = socketFd;
     m_clientSide = false;
     m_type = TCP_SOCKET;
+    m_isConnected = true;
 }
 
 /**

--- a/src/tls_tcp/tls_tcp_socket.cpp
+++ b/src/tls_tcp/tls_tcp_socket.cpp
@@ -56,6 +56,7 @@ TlsTcpSocket::TlsTcpSocket(const int socketFd,
     m_keyFile = keyFile;
     m_caFile = caFile;
     m_type = TLS_TCP_SOCKET;
+    m_isConnected = true;
 }
 
 /**
@@ -74,6 +75,10 @@ TlsTcpSocket::~TlsTcpSocket()
 bool
 TlsTcpSocket::initClientSide()
 {
+    if(m_isConnected) {
+        return true;
+    }
+
     bool result = initSocket();
     if(result == false) {
         return false;
@@ -84,6 +89,7 @@ TlsTcpSocket::initClientSide()
         return false;
     }
 
+    m_isConnected = true;
     LOG_INFO("Successfully initialized encrypted tcp-socket client to targe: " + m_address);
 
     return true;

--- a/src/unix/unix_domain_socket.cpp
+++ b/src/unix/unix_domain_socket.cpp
@@ -37,11 +37,16 @@ UnixDomainSocket::UnixDomainSocket(const std::string socketFile)
 bool
 UnixDomainSocket::initClientSide()
 {
+    if(m_isConnected) {
+        return true;
+    }
+
     bool result = initSocket();
     if(result == false) {
         return false;
     }
 
+    m_isConnected = true;
     LOG_INFO("Successfully initialized unix-socket client to targe: " + m_socketFile);
 
     return true;
@@ -59,6 +64,7 @@ UnixDomainSocket::UnixDomainSocket(const int socketFd)
     m_socket = socketFd;
     m_clientSide = false;
     m_type = UNIX_SOCKET;
+    m_isConnected = true;
 }
 
 /**
@@ -91,6 +97,7 @@ UnixDomainSocket::initSocket()
     }
 
     m_socketAddr = address;
+    m_isConnected = true;
 
     return true;
 }

--- a/tests/libKitsuneNetwork/tcp/tcp_socket_tcp_server_test.cpp
+++ b/tests/libKitsuneNetwork/tcp/tcp_socket_tcp_server_test.cpp
@@ -80,6 +80,7 @@ TcpSocket_TcpServer_Test::checkConnectionInit()
     // init client
     m_socketClientSide = new TcpSocket("127.0.0.1", 12345);
     UNITTEST(m_socketClientSide->initClientSide(), true);
+    UNITTEST(m_socketClientSide->initClientSide(), true);
     UNITTEST(m_socketClientSide->getType(), AbstractSocket::TCP_SOCKET);
 
     usleep(10000);

--- a/tests/libKitsuneNetwork/tls_tcp/tls_tcp_socket_tls_tcp_server_test.cpp
+++ b/tests/libKitsuneNetwork/tls_tcp/tls_tcp_socket_tls_tcp_server_test.cpp
@@ -90,6 +90,7 @@ TlsTcpSocket_TlsTcpServer_Test::checkConnectionInit()
                                           "/tmp/cert.pem",
                                           "/tmp/key.pem");
     UNITTEST(m_socketClientSide->initClientSide(), true);
+    UNITTEST(m_socketClientSide->initClientSide(), true);
     UNITTEST(m_socketClientSide->getType(), AbstractSocket::TLS_TCP_SOCKET);
 
     usleep(10000);

--- a/tests/libKitsuneNetwork/unix/unix_domain_socket_unix_domain_server_test.cpp
+++ b/tests/libKitsuneNetwork/unix/unix_domain_socket_unix_domain_server_test.cpp
@@ -80,6 +80,7 @@ UnixDomainSocket_UnixDomainServer_Test::checkConnectionInit()
     // init client
     m_socketClientSide = new UnixDomainSocket("/tmp/sock.uds");
     UNITTEST(m_socketClientSide->initClientSide(), true);
+    UNITTEST(m_socketClientSide->initClientSide(), true);
     UNITTEST(m_socketClientSide->getType(), AbstractSocket::UNIX_SOCKET);
 
     usleep(10000);


### PR DESCRIPTION
After successfully created a socket (client or server side) the init is
skipped after called again and returned true.

close #37 